### PR TITLE
Add IOS-XR ntp-interface config parser

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ntp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ntp.g4
@@ -43,6 +43,7 @@ ntp_common
    | ntp_clock_period
    | ntp_commit
    | ntp_distribute
+   | ntp_interface
    | ntp_logging
    | ntp_max_associations
    | ntp_master
@@ -58,6 +59,14 @@ ntp_common
 ntp_distribute
 :
    DISTRIBUTE NEWLINE
+;
+
+ntp_if_inner: DISABLE NEWLINE;
+
+ntp_interface
+:
+   INTERFACE iname = interface_name NEWLINE
+   ntp_if_inner*
 ;
 
 ntp_logging
@@ -80,7 +89,6 @@ ntp_null
    (
       ALLOW
       | AUTHENTICATION_KEY
-      | INTERFACE
       | LOG_INTERNAL_SYNC
       | PASSIVE
    ) null_rest_of_line


### PR DESCRIPTION
IOS-XRで以下の ntp interface config を無視するための parser 変更です。(ここを通常の interface config として読んでしまって interface shutdown された状態になってしまう)
```
ntp
 interface TenGigE0/0
  disable
 !
 ...
!
```
